### PR TITLE
Updates to release 2.2.7

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 See <www.wings3d.com> (and/or <https://github.com/dgud/wings>)
 
 Create releases with:
- `flatpak-builder build-dir com.wings3d.WINGS.json`
+ `flatpak-builder --force-clean build-dir com.wings3d.WINGS.json`
 
 Test with:
  `flatpak-builder --run build-dir com.wings3d.WINGS.json wings`

--- a/com.wings3d.WINGS.json
+++ b/com.wings3d.WINGS.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.wings3d.WINGS",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "19.08",
+  "runtime-version": "20.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "wings",
   "rename-icon": "wings",
@@ -24,15 +24,15 @@
   "modules": [
     "shared-modules/glu/glu-9.json",
     {
-      "name": "wxWidgets-313",
+      "name": "wxWidgets-314",
       "config-opts": [
 	"--enable-compat28"
       ],
       "sources": [
         {
           "type": "archive",
-	  "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.3/wxWidgets-3.1.3.tar.bz2",
-	  "sha1": "18be15d7a9e5b733e647677d3e9bc476df727f73"
+	  "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.tar.bz2",
+	  "sha1": "f8c77e6336b5f6414b07e27baa489fb8abc620c4"
         }
       ]
     },
@@ -73,8 +73,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://erlang.org/download/otp_src_22.1.tar.gz",
-	  "md5": "c23a64fecec779fd2d07074553d4625e"
+          "url": "https://erlang.org/download/otp_src_23.3.tar.gz",
+	  "md5": "d6660705f01afbe3466c0a5de21ab361"
         }
       ]
     },
@@ -88,8 +88,8 @@
       "sources": [
         {
           "type": "file",
-	  "url": "https://github.com/erlang/rebar3/releases/download/3.12.0/rebar3",
-	  "sha256": "d39bda02dd30276b2803fdb64ff731723961007608aa38e7422e603def70dc55"
+	  "url": "https://github.com/erlang/rebar3/releases/download/3.13.3/rebar3",
+	  "sha256": "a97e5368a9fce873a23c71c9bb3a63e760a7ace60842460e4704db5cad4df54c"
         }
       ]
     },
@@ -98,14 +98,14 @@
 	"name": "opencl-headers",
 	"buildsystem": "simple",
 	"build-commands": [
-	    "cp -av opencl22/CL /app/include/",
+	    "cp -av CL /app/include/",
 	    "install -p -D -m 0644 LICENSE -t ${FLATPAK_DEST}/share/licenses/opencl-headers/"
 	],
 
 	"sources": [
 	    { "type": "git",
 	      "url": "https://github.com/KhronosGroup/OpenCL-Headers.git",
-	      "commit": "e986688daf750633898dfd3994e14a9e618f2aa5"
+	      "commit": "c57ba81c460ee97b6b9d0b8d18faf5ba6883114b" /* v2020.06.16 */
 	    }
 	]
     },
@@ -114,7 +114,7 @@
       "name": "cl",
       "buildsystem": "simple",
       "build-commands": [
-	/* OpenCL is optional and there is no headers in org.freedesktop.Sdk  18.08 */
+	/* OpenCL is optional and there is no headers in org.freedesktop.Sdk  20.08 */
 	"rebar3 compile || erlc -oebin src/*.erl && cp src/cl.app.src ebin/cl.app",
 	"install -d /app/lib/erlang/lib/cl/ebin /app/lib/erlang/lib/cl/priv /app/lib/erlang/lib/cl/include",
         "install -t /app/lib/erlang/lib/cl/ebin ebin/*",
@@ -133,6 +133,43 @@
     },
 
     {
+      "name": "eigen",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir ${FLATPAK_DEST}/_deps",
+        "mkdir ${FLATPAK_DEST}/_deps/eigen",
+        "cp -r . ${FLATPAK_DEST}/_deps/eigen"
+      ],
+
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/eigenteam/eigen-git-mirror.git",
+          "tag": "3.3.7",
+          "commit": "cf794d3b741a6278df169e58461f8529f43bce5d"
+        }
+      ]
+    },
+
+    {
+      "name": "libigl",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir ${FLATPAK_DEST}/_deps/libigl",
+        "cp -r . ${FLATPAK_DEST}/_deps/libigl"
+      ],
+
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/dgud/libigl.git",
+          "tag": "v2.1.0",
+          "commit": "f6b406427400ed7ddb56cfc2577b6af571827c8c"
+        }
+      ]
+    },
+
+    {
       "name": "wings",
       "buildsystem": "simple",
       "build-options": {
@@ -143,6 +180,7 @@
 	}
       },
       "build-commands": [
+        "mv ${FLATPAK_DEST}/_deps .",
 	"make unix",
 	"./wings-*-linux.bzip2.run",
 	"install -d /app/share/applications /app/share/appdata",
@@ -157,8 +195,8 @@
         {
 	  "type": "git",
 	  "url": "https://github.com/dgud/wings.git",
-	  "tag": "v2.2.6.1",
-	  "commit": "349e1668b0b5a4a7464f2f96ef2131a8c4e915bf"
+	  "tag": "v2.2.7",
+	  "commit": "a64f8f766cef0c197dc23d511764103d65ab376c"
         }
       ]
     }


### PR DESCRIPTION
It was updated the download links, checksum and commits for all needed
code source as well as it was added code to download the new Wings3D
dependencies (libigl and eigen).
Because the Wings build script was not able to download these dependencies,
it was needed to trick flatpak by downloading these git repositories before
they be processed by the Wings sandbox. The files were moved to a temporary
folder under $FLATPAK_DEST/_deps which was moved to Wings sandbox
later.

NOTE: Update all necessary data to build Wings3D v2.2.7